### PR TITLE
Add tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,12 @@
 all: link dependencies venv
 
 link:
-	sudo ln -s ${PWD}/interpreter.py /usr/local/bin/chci
+	test -s /usr/local/bin/chci || sudo ln -s ${PWD}/interpreter.py /usr/local/bin/chci
 	chmod u+x ${PWD}/interpreter.py
+
+test: all
+	$(CURDIR)/venv/bin/python -m unittest "tests.py"
+
 
 dependencies:
 	virtualenv --version

--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ while not (a == 2):
 exit
 ```
 
+Tests
+---------------
+Yes, this actually has tests! You can run them by
+```
+make test
+```
+
 Minor negatives
 ---------------
 

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,57 @@
+#!venv/bin/python
+# -*- coding: utf-8 -*-
+
+
+import unittest
+import tempfile
+from subprocess import call, DEVNULL
+
+__author__ = 'martin.voznik@heureka.cz'
+
+
+class TestForbiddenWords(unittest.TestCase):
+
+    def testWrongStrings(self):
+        string = """
+import random
+čosi teď bude ['a', 'b', 'c']
+Volám Čuprovi(random.choice(čosi))
+        """
+        self.assertEqual(1, _test_string(string))
+
+        string = """
+Budeme používat random
+čosi teď bude ['a', 'b', 'c']
+print(random.choice(čosi))
+        """
+        self.assertEqual(1, _test_string(string))
+
+        string = """
+Hele prostě tohle dělej dokuď do piče Je neni:
+    pass
+        """
+        self.assertEqual(1, _test_string(string))
+
+    def testCorrectStrings(self):
+        string = """
+Budeme používat random
+čosi teď bude ['a', 'b', 'c']
+Volám Čuprovi(random.choice(čosi))
+        """
+        self.assertEqual(0, _test_string(string))
+
+        string = """
+A to si piš kurva("hovno")
+        """
+        self.assertEqual(0, _test_string(string))
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+def _test_string(string):
+    with tempfile.NamedTemporaryFile('w+b', 0, suffix='.nohy') as file:
+        file.write(string.encode())
+
+        return call(['chci', file.name], stdout=DEVNULL)


### PR DESCRIPTION
I created some basic tests for `chci` interpreter, because we DO tests, right?

It tests correct command parsing and checks if forbidden commands can't be run.

Side effect is that it will test if `chci` interpreter is correctly installed into system, if it's not, tests can't even be run :)
